### PR TITLE
Initial commit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,18 @@
+name: Build Images Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Test AMD64 image
+        uses: aniongithub/pimod@0.3
+        with:
+          pifile: images/Amd64-Debian.Pifile

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,3 +16,4 @@ jobs:
         uses: aniongithub/pimod@0.3
         with:
           pifile: images/Amd64-Debian.Pifile
+          args: --resolv host

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Test AMD64 image
-        uses: aniongithub/pimod@0.3
+        uses: aniongithub/pimod@0.31
         with:
           pifile: images/Amd64-Debian.Pifile
-          args: --resolv host
+          resolv: host

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # zeropoint-os
 A ready-to-boot, immutable, container-first OS that runs from USB and manages devcontainer-based apps across one or more machines
+
+## Introduction
+
+Growing mistrust of centralized services, opaque platforms, user exploitation, price gouging, and subscription-based lock-in is driving a renewed interest in self-hosted services. This shift is clearly visible in the rapid growth of homelabs and the massive popularity of self-hosting content among technically capable users. 
+
+However, this space remains inaccessible to many: most available software is still designed for public cloud environments and professional DevOps teams, adding a high bar of entry to what should be easily accessible in this day and age.
+
+Zeropoint proposes a simpler model: an immutable, USB-bootable, container-first homelab appliance OS. It is designed to feel like an appliance:
+
+1. Plug in a USB drive containing Zeropoint
+2. Power it on
+3. Use the Zeropoint API/app to connect to one or more Zeropoint nodes
+4. Install, remove, or manage services from a publicly curated set of open-source AI services, applications, and utilities
+
+Zeropoint aims to make it trivial to stand up a personal infrastructure appliance spanning one or more nodes, capable of running AI workloads, private services, and self-owned alternatives to cloud platforms with minimal setup, predictable behavior, and easy recovery.
+
+The system emphasizes trust, transparency, determinism, portability, and developer ergonomics over generality or scale.                                                                                        

--- a/images/Amd64-Debian.Pifile
+++ b/images/Amd64-Debian.Pifile
@@ -1,0 +1,45 @@
+FROM https://cdimage.debian.org/images/cloud/bookworm/20251112-2294/debian-12-genericcloud-amd64-20251112-2294.tar.xz 1
+
+PUMP 500M
+
+RUN apt-get update
+RUN apt-get install -y cowsay
+
+# Add /usr/games to PATH for all users
+RUN bash -c 'echo "export PATH=\$PATH:/usr/games" >> /etc/profile.d/games-path.sh'
+
+# Install standard kernel for physical hardware (cloud kernel lacks many drivers)
+RUN apt-get install -y linux-image-amd64
+
+# Remove cloud-init and cloud kernel
+RUN apt-get purge -y cloud-init cloud-initramfs-growroot cloud-guest-utils linux-image-*-cloud-amd64 || true
+RUN rm -rf /etc/cloud /var/lib/cloud
+
+# Set root password (change 'debian' to your preferred password)
+RUN bash -c 'echo "root:debian" | chpasswd'
+
+# Configure network - DHCP on all ethernet interfaces
+RUN bash -c 'cat > /etc/systemd/network/20-wired.network << EOF
+[Match]
+Name=en*
+
+[Network]
+DHCP=yes
+EOF'
+RUN systemctl enable systemd-networkd systemd-resolved
+
+# Console
+RUN systemctl enable getty@tty1
+RUN sed -i 's/console=ttyS0[^ ]*//g' /etc/default/grub
+RUN sed -i 's/GRUB_CMDLINE_LINUX="/GRUB_CMDLINE_LINUX="console=tty0 /' /etc/default/grub
+
+# Label the *image* root partition and switch root selector to LABEL
+# Only modify the root partition line in fstab (starts with PARTUUID or UUID and mounts to /)
+RUN bash -c 'ROOTDEV="$(findmnt -n -o SOURCE /)" && e2label "$ROOTDEV" root'
+RUN bash -c 'sed -i "/[[:space:]]\/[[:space:]]/s|^PARTUUID=[^[:space:]]*|LABEL=root|" /etc/fstab'
+
+RUN update-initramfs -u
+RUN update-grub
+
+# Fix grub.cfg to use LABEL=root instead of PARTUUID (update-grub ignores GRUB_DEVICE)
+RUN bash -c 'sed -i "s|root=PARTUUID=[^ ]*|root=LABEL=root|g" /boot/grub/grub.cfg'


### PR DESCRIPTION
This pull request introduces a new build workflow for testing image builds, adds a detailed project introduction to the documentation, and creates a new PiMod build file for an AMD64 Debian-based image. The main themes are CI/CD automation, documentation improvement, and initial image build configuration.

**CI/CD Automation:**
* Added a new GitHub Actions workflow (`.github/workflows/build-test.yml`) to automatically build and test the AMD64 image on pull requests to the `main` branch. This uses the `aniongithub/pimod` action to build from the `images/Amd64-Debian.Pifile` definition.

**Documentation:**
* Expanded the `README.md` with an "Introduction" section explaining the motivation, goals, and usage model for Zeropoint OS, focusing on accessibility, trust, and ease of use for self-hosted services.

**Image Build Configuration:**
* Added a new PiMod build file (`images/Amd64-Debian.Pifile`) to define the steps for building an AMD64 Debian-based image, including package installation, network configuration, root password setup, and partition labeling for appliance-style booting.…md64-Debian.Pifile and update README with project introduction